### PR TITLE
Fix logger usage

### DIFF
--- a/upload_release.py
+++ b/upload_release.py
@@ -112,10 +112,10 @@ def main():
 
     headers = {'X-Gitlab-Token': gitlab_token}
     logger.info(headers)
-    logger(url)
+    logger.info(url)
     response = requests.post(url=url, headers=headers, data=data)
-    logger(response.status_code)
-    logger(response.text)
+    logger.info(response.status_code)
+    logger.info(response.text)
 
     if response.status_code > 400:
         raise Exception(response.text)


### PR DESCRIPTION
## Summary
- log info instead of calling logger as a function in `upload_release.py`

## Testing
- `python -m pip show requests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683a07dc410c8326aac0bd2d8fffdff2