### PR TITLE
Fix toggle compilation switch

### DIFF
--- a/Components/MainWindow/CSettingsDialogBox.xaml.cs
+++ b/Components/MainWindow/CSettingsDialogBox.xaml.cs
@@ -559,9 +559,9 @@ namespace Launcher.Components.MainWindow
 
             var tryExecute = toggle switch
             {
-                EToggle.Compilation => await CApi.ToggleEncryption(newValue is 1),
-                EToggle.Protection => await CApi.ToggleProtection(newValue is 1),
-                EToggle.Encryption => await CApi.ToggleEncryption(newValue is 1),
+                EToggle.Compilation => await CApi.ToggleCompilation(newValue is 1),
+                EToggle.Protection  => await CApi.ToggleProtection(newValue is 1),
+                EToggle.Encryption  => await CApi.ToggleEncryption(newValue is 1),
                 _ => throw new NotImplementedException()
             };
             if (!tryExecute.IsSuccess)


### PR DESCRIPTION
## Summary
- correct API call when changing compilation toggle

## Testing
- `dotnet build Launcher.csproj -clp:ErrorsOnly` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a0cd12b008326a7da0c33ace4e7cc